### PR TITLE
Fix framework release line derivation from CLI version

### DIFF
--- a/src/Util/Constants.php
+++ b/src/Util/Constants.php
@@ -1,14 +1,42 @@
 <?php
 
 use Assegai\Console\Core\Database\Enumerations\DatabaseType;
+use Assegai\Console\Util\Inspector;
 
 const PACKAGE_NAME_CORE = 'assegaiphp/core';
 const PACKAGE_NAME_CLI = 'assegaiphp/console';
 const PACKAGE_NAME_ORM = 'assegaiphp/orm';
 const PACKAGE_NAME_EVENTS = 'assegaiphp/events';
-const RECOMMENDED_CORE_VERSION_CONSTRAINT = '^0.8.0';
-const RECOMMENDED_ORM_VERSION_CONSTRAINT = '^0.7.6';
-const RECOMMENDED_EVENTS_VERSION_CONSTRAINT = '*';
+const RECOMMENDED_FRAMEWORK_RELEASE_LINE_FALLBACK = '^0.8.0';
+
+if (!function_exists('recommended_framework_release_line_for_version')) {
+    function recommended_framework_release_line_for_version(string $version): string
+    {
+        if (preg_match('/(\d+)\.(\d+)/', $version, $matches) !== 1) {
+            return RECOMMENDED_FRAMEWORK_RELEASE_LINE_FALLBACK;
+        }
+
+        return sprintf('^%s.%s.0', $matches[1], $matches[2]);
+    }
+}
+
+if (!function_exists('recommended_framework_release_line')) {
+    function recommended_framework_release_line(?string $version = null): string
+    {
+        $version = $version ?? Inspector::getRunningCLIVersion();
+
+        if (!is_string($version) || trim($version) === '') {
+            return RECOMMENDED_FRAMEWORK_RELEASE_LINE_FALLBACK;
+        }
+
+        return recommended_framework_release_line_for_version($version);
+    }
+}
+
+define('RECOMMENDED_FRAMEWORK_RELEASE_LINE', recommended_framework_release_line());
+define('RECOMMENDED_CORE_VERSION_CONSTRAINT', RECOMMENDED_FRAMEWORK_RELEASE_LINE);
+define('RECOMMENDED_ORM_VERSION_CONSTRAINT', RECOMMENDED_FRAMEWORK_RELEASE_LINE);
+define('RECOMMENDED_EVENTS_VERSION_CONSTRAINT', '*');
 const DEFAULT_PROJECT_NAME = 'assegai-app';
 const DEFAULT_PROJECT_VERSION = '0.0.1';
 const DEFAULT_PROJECT_TYPE = 'project';

--- a/templates/index.php
+++ b/templates/index.php
@@ -13,8 +13,8 @@ if ($publicDirectory !== false && $requestPath !== '/' && $requestPath !== '') {
   $segments = $assetRelativePath === '' ? [] : array_values(array_filter(explode('/', $assetRelativePath), static fn(string $segment): bool => $segment !== ''));
   $hasHiddenSegment = false;
 
-  foreach ($segments as $segment) {
-    if (str_starts_with($segment, '.')) {
+  foreach ($segments as $index => $segment) {
+    if (str_starts_with($segment, '.') && !($index === 0 && $segment === '.well-known')) {
       $hasHiddenSegment = true;
       break;
     }

--- a/tests/Feature/NewProjectDefaultsTest.php
+++ b/tests/Feature/NewProjectDefaultsTest.php
@@ -128,6 +128,7 @@ describe('New project defaults', function () {
       ->toContain("realpath(__DIR__ . '/public')")
       ->toContain('X-Content-Type-Options: nosniff')
       ->toContain('readfile($assetPath);')
-      ->toContain("!in_array(\$extension, ['php', 'phtml', 'phar', 'inc'], true)");
+      ->toContain("!in_array(\$extension, ['php', 'phtml', 'phar', 'inc'], true)")
+      ->toContain("\$segment === '.well-known'");
   });
 });

--- a/tests/Unit/ProjectTemplateDefaultsTest.php
+++ b/tests/Unit/ProjectTemplateDefaultsTest.php
@@ -40,4 +40,15 @@ describe('Project template defaults', function () {
     expect($composer['require']['php'])->toBe('^' . MIN_PHP_VERSION);
     expect($composer['autoload']['psr-4'])->toBe([]);
   });
+
+  it('keeps the recommended orm dependency on the same release line as core', function () {
+    expect(RECOMMENDED_ORM_VERSION_CONSTRAINT)->toBe(RECOMMENDED_CORE_VERSION_CONSTRAINT);
+  });
+
+  it('derives framework release lines from semantic CLI versions', function () {
+    expect(recommended_framework_release_line_for_version('0.8.2'))->toBe('^0.8.0');
+    expect(recommended_framework_release_line_for_version('v0.9.4'))->toBe('^0.9.0');
+    expect(recommended_framework_release_line_for_version('0.10.x-dev'))->toBe('^0.10.0');
+    expect(recommended_framework_release_line_for_version('1.1.3'))->toBe('^1.1.0');
+  });
 });


### PR DESCRIPTION
This pull request introduces improvements to how recommended framework version constraints are determined and used, particularly for dependency management. It also refines asset path handling to better support `.well-known` directories and updates related tests to ensure correctness.

**Dependency version constraint improvements:**

* Added logic in `src/Util/Constants.php` to dynamically derive the recommended framework release line based on the running CLI version, ensuring that `RECOMMENDED_CORE_VERSION_CONSTRAINT` and `RECOMMENDED_ORM_VERSION_CONSTRAINT` are always aligned and up-to-date. This replaces previous hardcoded version constraints.
* Introduced helper functions `recommended_framework_release_line_for_version` and `recommended_framework_release_line` to parse semantic versions and generate appropriate version constraints.
* Updated unit tests in `tests/Unit/ProjectTemplateDefaultsTest.php` to verify that ORM and core dependencies use the same release line and that the release line is correctly derived from various semantic CLI versions.

**Asset path handling improvements:**

* Modified the asset path filtering logic in `templates/index.php` to allow `.well-known` as a valid segment, while still excluding other hidden segments (those starting with a dot).
* Updated feature tests in `tests/Feature/NewProjectDefaultsTest.php` to confirm that `.well-known` is correctly handled as an allowed segment.
