### PR TITLE
Restore stability of fresh app scaffold

### DIFF
--- a/src/Commands/Serve.php
+++ b/src/Commands/Serve.php
@@ -90,6 +90,7 @@ class Serve extends Command
     }
 
     $uri = $this->buildServeUri((string) $host, (int) $port);
+    $documentRoot = $this->resolveDocumentRoot($root);
 
     if ($runtime !== 'php' && $https) {
       $output->writeln('<error>The selected runtime does not support the --https serve path yet.</error>');
@@ -110,6 +111,7 @@ class Serve extends Command
       workingDirectory: $root,
       host: (string) $host,
       port: (int) $port,
+      documentRoot: $documentRoot,
       router: $router,
       bootstrap: $bootstrap,
       https: (bool) $https,
@@ -425,6 +427,7 @@ class Serve extends Command
     string $workingDirectory,
     string $host,
     int $port,
+    string $documentRoot,
     string $router,
     string $bootstrap,
     bool $https = false,
@@ -435,7 +438,9 @@ class Serve extends Command
     $environmentPrefix = $this->buildRuntimeEnvironmentPrefix($runtime, $host, $port, $workingDirectory);
 
     if ($runtime === 'php') {
-      $command = $environmentPrefix . ' php -S ' . escapeshellarg($uri) . ' ' . escapeshellarg($router);
+      $command = $environmentPrefix . ' php -S ' . escapeshellarg($uri)
+        . ' -t ' . escapeshellarg($documentRoot)
+        . ' ' . escapeshellarg($router);
 
       if ($https && $certPath !== null && $keyPath !== null) {
         $command .= ' --cert ' . escapeshellarg($certPath) . ' --key ' . escapeshellarg($keyPath);
@@ -445,6 +450,13 @@ class Serve extends Command
     }
 
     return $environmentPrefix . ' ' . escapeshellarg(PHP_BINARY) . ' ' . escapeshellarg($bootstrap);
+  }
+
+  protected function resolveDocumentRoot(string $workingDirectory): string
+  {
+    $publicDirectory = Path::join($workingDirectory, 'public');
+
+    return is_dir($publicDirectory) ? $publicDirectory : $workingDirectory;
   }
 
   protected function buildRuntimeEnvironmentPrefix(string $runtime, string $host, int $port, string $workingDirectory): string

--- a/src/Installers/DatabaseInstaller.php
+++ b/src/Installers/DatabaseInstaller.php
@@ -234,9 +234,9 @@ class DatabaseInstaller extends AbstractInstaller
         }
 
         $entityClassConstant = $this->buildUserEntityClassConstant();
-        $updatedContents = preg_replace(
+        $updatedContents = preg_replace_callback(
             "/(^\s*'entityClassName'\s*=>\s*)([^,]+)(,\s*$)/m",
-            "${1}{$entityClassConstant}${3}",
+            static fn(array $matches): string => $matches[1] . $entityClassConstant . $matches[3],
             $contents,
             1,
             $replacementCount

--- a/templates/index.php
+++ b/templates/index.php
@@ -9,109 +9,15 @@ $publicDirectory = realpath(__DIR__ . '/public');
 $requestPath = parse_url($_SERVER['REQUEST_URI'] ?? '/', PHP_URL_PATH) ?: '/';
 
 if ($publicDirectory !== false && $requestPath !== '/' && $requestPath !== '') {
-  $assetRelativePath = trim(str_replace('\\', '/', ltrim($requestPath, '/')), '/');
-  $segments = $assetRelativePath === '' ? [] : array_values(array_filter(explode('/', $assetRelativePath), static fn(string $segment): bool => $segment !== ''));
-  $hasHiddenSegment = false;
+  $assetPath = assegai_resolve_public_asset_path($publicDirectory, $requestPath);
+  $documentRoot = realpath($_SERVER['DOCUMENT_ROOT'] ?? '');
 
-  foreach ($segments as $index => $segment) {
-    if (str_starts_with($segment, '.') && !($index === 0 && $segment === '.well-known')) {
-      $hasHiddenSegment = true;
-      break;
-    }
-  }
-
-  if (!$hasHiddenSegment && $assetRelativePath !== '') {
-    $assetCandidate = $publicDirectory . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $assetRelativePath);
-    $assetPath = realpath($assetCandidate);
-    $extension = strtolower(pathinfo($assetPath ?: '', PATHINFO_EXTENSION));
-    $normalizedRelativePath = trim(str_replace('\\', '/', $assetRelativePath), '/');
-    $shouldBypassStreaming = false;
-
-    if (in_array($extension, ['php', 'phtml', 'phar', 'inc'], true)) {
-      $shouldBypassStreaming = true;
-    } elseif ($extension === '') {
-      $shouldBypassStreaming = !str_starts_with($normalizedRelativePath, '.well-known/');
-    } else {
-      $allowedExtensions = [
-        '7z',
-        'atom',
-        'avif',
-        'bmp',
-        'bz2',
-        'css',
-        'csv',
-        'eot',
-        'gif',
-        'gz',
-        'htm',
-        'html',
-        'ico',
-        'jpeg',
-        'jpg',
-        'js',
-        'json',
-        'map',
-        'md',
-        'mjs',
-        'mp3',
-        'mp4',
-        'mpeg',
-        'oga',
-        'ogv',
-        'ogx',
-        'otf',
-        'pdf',
-        'png',
-        'rss',
-        'rtf',
-        'svg',
-        'svgz',
-        'tgz',
-        'ts',
-        'ttf',
-        'txt',
-        'wasm',
-        'wav',
-        'weba',
-        'webm',
-        'webmanifest',
-        'webp',
-        'woff',
-        'woff2',
-        'xhtml',
-        'xls',
-        'xlsx',
-        'xml',
-        'zip',
-      ];
-
-      $shouldBypassStreaming = !in_array($extension, $allowedExtensions, true)
-        || in_array(
-          strtolower(pathinfo($assetPath ?: '', PATHINFO_BASENAME)),
-          ['index.htm', 'index.html', 'index.php', 'index.xhtml'],
-          true,
-        );
+  if (is_string($assetPath)) {
+    if (PHP_SAPI === 'cli-server' && $documentRoot === $publicDirectory) {
+      return false;
     }
 
-    if (
-      $assetPath !== false
-      && is_file($assetPath)
-      && str_starts_with($assetPath, $publicDirectory . DIRECTORY_SEPARATOR)
-      && !$shouldBypassStreaming
-    ) {
-      $mimeType = mime_content_type($assetPath) ?: 'application/octet-stream';
-      $contentLength = filesize($assetPath);
-
-      header("Content-Type: $mimeType");
-      header('X-Content-Type-Options: nosniff');
-
-      if (is_int($contentLength) && $contentLength >= 0) {
-        header('Content-Length: ' . $contentLength);
-      }
-
-      readfile($assetPath);
-      exit();
-    }
+    assegai_stream_public_asset($assetPath);
   }
 }
 
@@ -130,3 +36,148 @@ if (!isset($_GET['path']) || $_GET['path'] === '') {
 }
 
 require_once './bootstrap.php';
+
+function assegai_resolve_public_asset_path(string $publicDirectory, string $requestPath): string|false
+{
+  $assetRelativePath = trim(str_replace('\\', '/', ltrim($requestPath, '/')), '/');
+
+  if ($assetRelativePath === '' || assegai_contains_hidden_path_segment($assetRelativePath)) {
+    return false;
+  }
+
+  $assetCandidate = $publicDirectory . DIRECTORY_SEPARATOR . str_replace('/', DIRECTORY_SEPARATOR, $assetRelativePath);
+  $assetPath = realpath($assetCandidate);
+
+  if ($assetPath === false || !is_file($assetPath)) {
+    return false;
+  }
+
+  $publicDirectoryPrefix = rtrim($publicDirectory, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+  if (!str_starts_with($assetPath, $publicDirectoryPrefix)) {
+    return false;
+  }
+
+  return assegai_should_serve_public_asset($assetPath, $assetRelativePath) ? $assetPath : false;
+}
+
+function assegai_contains_hidden_path_segment(string $relativePath): bool
+{
+  $segments = array_values(array_filter(explode('/', $relativePath), static fn(string $segment): bool => $segment !== ''));
+
+  foreach ($segments as $index => $segment) {
+    if (str_starts_with($segment, '.') && !($index === 0 && $segment === '.well-known')) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function assegai_should_serve_public_asset(string $assetPath, string $relativePath): bool
+{
+  $extension = strtolower(pathinfo($assetPath, PATHINFO_EXTENSION));
+  $normalizedRelativePath = trim(str_replace('\\', '/', $relativePath), '/');
+
+  if (in_array($extension, ['php', 'phtml', 'phar', 'inc'], true)) {
+    return false;
+  }
+
+  if ($extension === '') {
+    return str_starts_with($normalizedRelativePath, '.well-known/');
+  }
+
+  $allowedExtensions = [
+    '7z',
+    'atom',
+    'avif',
+    'bmp',
+    'bz2',
+    'css',
+    'csv',
+    'eot',
+    'gif',
+    'gz',
+    'htm',
+    'html',
+    'ico',
+    'jpeg',
+    'jpg',
+    'js',
+    'json',
+    'map',
+    'md',
+    'mjs',
+    'mp3',
+    'mp4',
+    'mpeg',
+    'oga',
+    'ogv',
+    'ogx',
+    'otf',
+    'pdf',
+    'png',
+    'rss',
+    'rtf',
+    'svg',
+    'svgz',
+    'tgz',
+    'ts',
+    'ttf',
+    'txt',
+    'wasm',
+    'wav',
+    'weba',
+    'webm',
+    'webmanifest',
+    'webp',
+    'woff',
+    'woff2',
+    'xhtml',
+    'xls',
+    'xlsx',
+    'xml',
+    'zip',
+  ];
+
+  if (!in_array($extension, $allowedExtensions, true)) {
+    return false;
+  }
+
+  return !in_array(
+    strtolower(pathinfo($assetPath, PATHINFO_BASENAME)),
+    ['index.htm', 'index.html', 'index.php', 'index.xhtml'],
+    true,
+  );
+}
+
+function assegai_public_asset_mime_type(string $assetPath): string
+{
+  $mimeType = mime_content_type($assetPath);
+
+  return match (strtolower(pathinfo($assetPath, PATHINFO_EXTENSION))) {
+    'css' => 'text/css',
+    'js', 'mjs' => 'text/javascript',
+    'json', 'map', 'webmanifest' => 'application/json',
+    'svg', 'svgz' => 'image/svg+xml',
+    'wasm' => 'application/wasm',
+    'woff' => 'font/woff',
+    'woff2' => 'font/woff2',
+    default => is_string($mimeType) ? $mimeType : 'application/octet-stream',
+  };
+}
+
+function assegai_stream_public_asset(string $assetPath): never
+{
+  $contentLength = filesize($assetPath);
+
+  header('Content-Type: ' . assegai_public_asset_mime_type($assetPath));
+  header('X-Content-Type-Options: nosniff');
+
+  if (is_int($contentLength) && $contentLength >= 0) {
+    header('Content-Length: ' . $contentLength);
+  }
+
+  readfile($assetPath);
+  exit();
+}

--- a/tests/Feature/NewProjectDefaultsTest.php
+++ b/tests/Feature/NewProjectDefaultsTest.php
@@ -15,6 +15,49 @@ if (! function_exists('env')) {
   }
 }
 
+function createNewProjectDefaultsWorkspace(): string
+{
+  $workspace = sys_get_temp_dir() . '/' . uniqid('new-project-defaults-', true);
+
+  if (! mkdir($workspace . '/config', 0755, true) && ! is_dir($workspace . '/config')) {
+    throw new RuntimeException("Failed to create test workspace: $workspace");
+  }
+
+  copy(__DIR__ . '/../../templates/config/secure.php', $workspace . '/config/secure.php');
+  file_put_contents($workspace . '/composer.json', json_encode([
+    'autoload' => [
+      'psr-4' => [
+        'Acme\\Saas\\' => 'src/',
+      ],
+    ],
+  ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+  return $workspace;
+}
+
+function deleteNewProjectDefaultsWorkspace(string $directory): void
+{
+  if (! is_dir($directory)) {
+    return;
+  }
+
+  $items = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::CHILD_FIRST
+  );
+
+  foreach ($items as $item) {
+    if ($item->isDir()) {
+      rmdir($item->getPathname());
+      continue;
+    }
+
+    unlink($item->getPathname());
+  }
+
+  rmdir($directory);
+}
+
 describe('New project defaults', function () {
   it('forces ansi when generating the default users resource', function () {
     $installer = new class(
@@ -60,6 +103,54 @@ describe('New project defaults', function () {
     expect($secureConfig['authentication']['strategies'])->toBe([]);
     expect($secureConfig['authentication']['jwt']['entityClassName'])
       ->toBe('Assegai\\App\\Users\\Entities\\UserEntity');
+  });
+
+  it('syncs secure auth defaults without regex replacement interpolation warnings', function () {
+    $workspace = createNewProjectDefaultsWorkspace();
+    $warnings = [];
+
+    try {
+      $installer = new class(
+        new MockInput(),
+        new MockOutput(),
+        new FormatterHelper(),
+        new QuestionHelper(),
+        $workspace
+      ) extends DatabaseInstaller {
+        public function syncForResource(string $resourceName): int
+        {
+          $this->userResourceName = $resourceName;
+
+          return $this->syncSecureAuthenticationDefaults();
+        }
+      };
+
+      set_error_handler(static function (int $severity, string $message) use (&$warnings): bool {
+        if ($severity === E_WARNING || $severity === E_NOTICE || $severity === E_USER_WARNING) {
+          $warnings[] = $message;
+        }
+
+        return true;
+      });
+
+      try {
+        $status = $installer->syncForResource('Team Members');
+      } finally {
+        restore_error_handler();
+      }
+
+      $secureConfigContents = file_get_contents($workspace . '/config/secure.php') ?: '';
+      $secureConfig = require $workspace . '/config/secure.php';
+
+      expect($status)->toBe(Command::SUCCESS);
+      expect($warnings)->toBe([]);
+      expect($secureConfigContents)
+        ->toContain("'entityClassName' => Acme\\Saas\\TeamMembers\\Entities\\TeamMemberEntity::class");
+      expect($secureConfig['authentication']['jwt']['entityClassName'])
+        ->toBe('Acme\\Saas\\TeamMembers\\Entities\\TeamMemberEntity');
+    } finally {
+      deleteNewProjectDefaultsWorkspace($workspace);
+    }
   });
 
   it('offers module data_source enablement after configuring databases during project setup', function () {
@@ -221,10 +312,15 @@ describe('New project defaults', function () {
     expect($frontController)
       ->toContain("realpath(__DIR__ . '/public')")
       ->toContain('X-Content-Type-Options: nosniff')
+      ->toContain("PHP_SAPI === 'cli-server'")
+      ->toContain("realpath(" . '$_SERVER' . "['DOCUMENT_ROOT'] ?? '')")
+      ->toContain('return false;')
+      ->toContain('assegai_stream_public_asset($assetPath);')
       ->toContain('readfile($assetPath);')
       ->toContain("\$allowedExtensions = [")
-      ->toContain("!str_starts_with(\$normalizedRelativePath, '.well-known/')")
-      ->toContain('!$shouldBypassStreaming')
+      ->toContain("return str_starts_with(\$normalizedRelativePath, '.well-known/');")
+      ->toContain("'css' => 'text/css'")
+      ->toContain("'js', 'mjs' => 'text/javascript'")
       ->toContain("\$segment === '.well-known'");
   });
 

--- a/tests/Feature/ServeTest.php
+++ b/tests/Feature/ServeTest.php
@@ -118,6 +118,7 @@ describe('Serve', function () {
       expect($command->calls[1]['type'])->toBe('serve');
       expect($command->calls[1]['command'])->toContain("ASSEGAI_RUNTIME='php'");
       expect($command->calls[1]['command'])->toContain("php -S '127.0.0.1:5050'");
+      expect($command->calls[1]['command'])->toContain('-t ' . escapeshellarg($workspace . '/public'));
       expect($command->calls[1]['command'])->toContain($workspace . '/index.php');
       expect($command->calls[2])->toMatchArray([
         'type' => 'stop-watch',

--- a/tests/Unit/RegexReplacementSafetyTest.php
+++ b/tests/Unit/RegexReplacementSafetyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+describe('regex replacement safety', function () {
+  it('does not use PHP-interpolated numeric regex replacement backreferences', function () {
+    $roots = [
+      __DIR__ . '/../../src',
+      __DIR__ . '/../../templates',
+    ];
+    $violations = [];
+
+    foreach ($roots as $root) {
+      $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+      );
+
+      foreach ($files as $file) {
+        if (! $file->isFile()) {
+          continue;
+        }
+
+        $filename = $file->getPathname();
+        $contents = file_get_contents($filename);
+
+        if ($contents === false) {
+          continue;
+        }
+
+        if (preg_match('/\$\{[0-9]+}/', $contents) === 1) {
+          $violations[] = $filename . ' contains ${n} interpolation syntax';
+        }
+
+        if (preg_match('/preg_replace\s*\((?:[^;]|\R){0,400}?,\s*"[^"]*\$[0-9]/m', $contents) === 1) {
+          $violations[] = $filename . ' contains double-quoted preg_replace numeric backreferences';
+        }
+      }
+    }
+
+    expect($violations)->toBe([]);
+  });
+});


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the codebase, focusing on safer regex usage, enhancements to the PHP development server command, and more robust static asset handling in the front controller. It also adds comprehensive tests to ensure these changes work as expected and to prevent regression.

**Serve command improvements:**

- The `php -S` development server command now explicitly sets the document root using the `-t` flag, ensuring static assets are served correctly from the `public` directory. The document root is resolved dynamically based on the project structure. (`src/Commands/Serve.php`, `tests/Feature/ServeTest.php`) [[1]](diffhunk://#diff-5c39c0f8c8ce79b1ae8411fe2fc20fd7bf1842e1b66f559797d5a3c9325cf37eR93) [[2]](diffhunk://#diff-5c39c0f8c8ce79b1ae8411fe2fc20fd7bf1842e1b66f559797d5a3c9325cf37eR114) [[3]](diffhunk://#diff-5c39c0f8c8ce79b1ae8411fe2fc20fd7bf1842e1b66f559797d5a3c9325cf37eR430) [[4]](diffhunk://#diff-5c39c0f8c8ce79b1ae8411fe2fc20fd7bf1842e1b66f559797d5a3c9325cf37eL438-R443) [[5]](diffhunk://#diff-5c39c0f8c8ce79b1ae8411fe2fc20fd7bf1842e1b66f559797d5a3c9325cf37eR455-R461) [[6]](diffhunk://#diff-2cdc7dbf5ea0fae7da7452cba5b4ff0f7013ba660fd18571111c5acf1d95773eR121)

**Front controller (static asset and CORS handling):**

- Refactored `templates/index.php` to safely resolve and serve public assets, preventing directory traversal and hidden file access. Static asset streaming is now handled in a dedicated function with improved MIME type detection. CORS headers are set early, and preflight OPTIONS requests are handled efficiently. (`templates/index.php`) [[1]](diffhunk://#diff-5258161aaab90de3916c094462a8b5035d08c02eff481989342aeca0a45c4be5R12-R89) [[2]](diffhunk://#diff-5258161aaab90de3916c094462a8b5035d08c02eff481989342aeca0a45c4be5L88-R174) [[3]](diffhunk://#diff-5258161aaab90de3916c094462a8b5035d08c02eff481989342aeca0a45c4be5L115-L132)

**Regex replacement safety:**

- Updated `DatabaseInstaller` to use `preg_replace_callback` instead of double-quoted replacement strings, preventing PHP interpolation warnings and potential bugs. (`src/Installers/DatabaseInstaller.php`)
- Added a unit test to enforce safe regex replacement patterns and prevent accidental use of interpolated numeric backreferences. (`tests/Unit/RegexReplacementSafetyTest.php`)

**Testing improvements:**

- Added and extended feature tests to verify that secure authentication defaults are updated without regex warnings, and that the new asset and CORS handling logic is present in the front controller. Helper functions were introduced to manage test workspaces. (`tests/Feature/NewProjectDefaultsTest.php`) [[1]](diffhunk://#diff-07e92f1cfc7fd7f8991320d030127db9bc91771cad50092dc240bd61a58e6c9bR18-R60) [[2]](diffhunk://#diff-07e92f1cfc7fd7f8991320d030127db9bc91771cad50092dc240bd61a58e6c9bR108-R155) [[3]](diffhunk://#diff-07e92f1cfc7fd7f8991320d030127db9bc91771cad50092dc240bd61a58e6c9bR315-R323)

These changes together improve the reliability, security, and maintainability of the development workflow and the application’s request handling.