### PR TITLE
feat(console): add .gitignore template and implement file creation in WorkspaceManager

### DIFF
--- a/src/Commands/Database/DatabaseConfigure.php
+++ b/src/Commands/Database/DatabaseConfigure.php
@@ -5,11 +5,8 @@ namespace Assegai\Console\Commands\Database;
 use Assegai\Console\Core\Database\Enumerations\DatabaseType;
 use Assegai\Console\Core\Modules\ModuleDataSourceConfigurator;
 use Assegai\Console\Exceptions\AssegaiConsoleException;
-use Assegai\Console\Prompts\CliPrompt;
-use Assegai\Console\Util\Config\DBConfig;
 use Assegai\Console\Util\Enumerations\ParameterKey;
 use Assegai\Console\Util\Inspector;
-use Assegai\Console\Util\Path;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -58,7 +55,6 @@ class DatabaseConfigure extends Command
   {
     $inspector = new Inspector($input, $output);
     $workingDirectory = getcwd() ?: '';
-    $configFilename = Path::join($workingDirectory, 'config', 'local.php');
     $type = get_datasource_type($input, $output) ?: throw new AssegaiConsoleException('Database type is not specified. Use the --db-type option to specify the database type.');
 
     if (! $inspector->isValidWorkspace($workingDirectory)) {
@@ -70,133 +66,14 @@ class DatabaseConfigure extends Command
       return Command::FAILURE;
     }
 
-    if (! file_exists($configFilename)) {
-      $configFilename = Path::join($workingDirectory, 'config', 'default.php');
+    $name = (string) $input->getArgument(ParameterKey::DB_NAME->value);
 
-      if (! file_exists($configFilename)) {
-        $output->writeln([
-          '',
-          '<error>The configuration file does not exist.</error>',
-          '',
-        ]);
-        return Command::FAILURE;
-      }
-    }
-
-    $prompts = new CliPrompt($input, $output);
-    $name = $input->getArgument(ParameterKey::DB_NAME->value);
-
-    if ($type === DatabaseType::SQLITE->value) {
-      $output->writeln([
-        '',
-        'Configuring the SQLite database...',
-        '',
-      ]);
-
-      $dsn = 'sqlite:';
-      $choices = ['on-disk', 'in-memory', 'in-memory (persistent)'];
-
-      $sqlType = (string) $prompts->select('How do you want to store your data?', $choices, 0);
-
-      $dsn .= match ($sqlType) {
-        'on-disk' => ".data/$name.sq3",
-        'in-memory (persistent)' => 'file::memory:?cache=shared',
-        default => ':memory:',
-      };
-
-      $dbConfig = new DBConfig($input, $output, $name, $type);
-      if (Command::SUCCESS !== $dbConfig->load()) {
-        $output->writeln([
-          '',
-          '<error>Failed to load database configuration.</error>',
-          '',
-        ]);
-        return Command::FAILURE;
-      }
-
-      $dbConfig->set("$type.$name", ['path' => str_replace('sqlite:', '', $dsn)]);
-
-      if (Command::SUCCESS !== $dbConfig->commit()) {
-        $output->writeln('<error>Failed to save database configuration.</error>');
-        return Command::FAILURE;
-      }
-
-      return $this->configureModuleDataSource(
-        qualify_datasource_name($type, (string) $name),
-        $input,
-        $output,
-      );
-    }
-
-    $host = $input->getOption('host');
-    $port = $input->getOption('port');
-    $user = $input->getOption('user');
-    $password = $input->getOption('password');
-
-    $output->writeln("Configuring the database <info>$name</info>...");
-
-    if (! $host) {
-      $defaultHost = match ($type) {
-        DatabaseType::MYSQL->value => DEFAULT_MYSQL_HOST,
-        DatabaseType::MARIADB->value => DEFAULT_MARIADB_HOST,
-        DatabaseType::POSTGRESQL->value => DEFAULT_POSTGRES_HOST,
-        DatabaseType::MSSQL->value => DEFAULT_MSSQL_HOST,
-        default => '',
-      };
-      $host = $prompts->text('Host', $defaultHost);
-    }
-
-    if (! $port) {
-      $defaultPort = match ($type) {
-        DatabaseType::MYSQL->value => DEFAULT_MYSQL_PORT,
-        DatabaseType::MARIADB->value => DEFAULT_MARIADB_PORT,
-        DatabaseType::POSTGRESQL->value => DEFAULT_POSTGRES_PORT,
-        DatabaseType::MSSQL->value => DEFAULT_MSSQL_PORT,
-        default => '',
-      };
-      $port = $prompts->text('Port', (string) $defaultPort);
-    }
-
-    if (! $user) {
-      $defaultUser = match ($type) {
-        DatabaseType::MYSQL->value => DEFAULT_MYSQL_USER,
-        DatabaseType::MARIADB->value => DEFAULT_MARIADB_USER,
-        DatabaseType::POSTGRESQL->value => DEFAULT_POSTGRES_USER,
-        DatabaseType::MSSQL->value => DEFAULT_MSSQL_USER,
-        default => '',
-      };
-      $user = $prompts->text('User', $defaultUser);
-    }
-
-    if ($password === null || $password === false) {
-      $password = $prompts->password('Password');
-    }
-
-    $dbConfig = new DBConfig($input, $output, $name, $type);
-    if (Command::SUCCESS !== $dbConfig->load()) {
-      $output->writeln([
-        '',
-        '<error>Failed to load database configuration.</error>',
-        '',
-      ]);
-      return Command::FAILURE;
-    }
-
-    $dbConfig->set("$type.$name", [
-      'host' => $host,
-      'port' => (int) $port,
-      'user' => $user,
-      'password' => $password,
-    ]);
-
-    $output->writeln('');
-    if ($dbConfig->commit() !== Command::SUCCESS) {
-      $output->writeln('<error>Failed to save database configuration.</error>');
+    if (Command::SUCCESS !== configure_datasource($input, $output, $type, $name, $workingDirectory)) {
       return Command::FAILURE;
     }
 
     return $this->configureModuleDataSource(
-      qualify_datasource_name($type, (string) $name),
+      qualify_datasource_name($type, $name),
       $input,
       $output,
     );

--- a/src/Commands/Migration/MigrationCreate.php
+++ b/src/Commands/Migration/MigrationCreate.php
@@ -73,7 +73,7 @@ class MigrationCreate extends Command
       return Command::FAILURE;
     }
 
-    $type = get_datasource_type($input, $output);
+    $type = get_datasource_type($input, $output, ParameterKey::DB_TYPE->value, self::OPTION_DB_NAME);
 
     if (false === $type) {
       $output->writeln("<error>Failed to get database type.</error>\n");

--- a/src/Commands/Migration/MigrationSetup.php
+++ b/src/Commands/Migration/MigrationSetup.php
@@ -10,7 +10,6 @@ use Assegai\Console\Core\Database\MySQLDatabase;
 use Assegai\Console\Core\Database\PostgreSQLDatabase;
 use Assegai\Console\Core\Database\SQLiteDatabase;
 use Assegai\Console\Prompts\CliPrompt;
-use Assegai\Console\Util\Config\DBConfig;
 use Assegai\Console\Util\Enumerations\ParameterKey;
 use Assegai\Console\Util\Inspector;
 use Assegai\Console\Util\Path;
@@ -34,6 +33,10 @@ class MigrationSetup extends Command
       ->setHelp('This command sets up the migrations table in the database and creates the migrations directory in the project root')
       ->addArgument(ParameterKey::DB_NAME->value, InputArgument::REQUIRED, 'The name of the database')
       ->addOption(ParameterKey::DB_TYPE->value, ParameterKey::DB_TYPE->getShortName(), InputArgument::OPTIONAL, 'The type of the database', DEFAULT_DATABASE_TYPE, DatabaseType::toArray())
+      ->addOption('host', 'H', InputArgument::OPTIONAL, 'The host of the database when creating a missing connection config')
+      ->addOption('port', 'P', InputArgument::OPTIONAL, 'The port of the database when creating a missing connection config')
+      ->addOption('user', 'u', InputArgument::OPTIONAL, 'The user of the database when creating a missing connection config')
+      ->addOption('password', 'p', InputArgument::OPTIONAL, 'The password of the database when creating a missing connection config')
       ->addOption(DatabaseType::MYSQL->value, null, InputOption::VALUE_NONE, 'Use MySQL database')
       ->addOption(DatabaseType::MARIADB->value, null, InputOption::VALUE_NONE, 'Use MariaDB database')
       ->addOption(DatabaseType::POSTGRESQL->value, null, InputOption::VALUE_NONE, 'Use PostgreSQL database')
@@ -53,16 +56,24 @@ class MigrationSetup extends Command
     }
 
     $migrationsDirectory = Path::join($root, 'migrations');
-    $defaultDatabaseType = DEFAULT_DATABASE_TYPE;
-    $databaseType = get_datasource_type($input, $output) ?: (string) $prompts->select(
-      'Enter the database type',
-      DatabaseType::toArray(),
-      $defaultDatabaseType
-    );
-
-    $databaseName =
+    $databaseName = (string) (
       $input->getArgument(ParameterKey::DB_NAME->value) ??
-      $prompts->text('Enter the database name');
+      $prompts->text('Enter the database name')
+    );
+    $databaseType = get_datasource_type($input, $output);
+
+    if (! $databaseType || ! DatabaseType::isValid($databaseType)) {
+      $output->writeln("<error>Invalid database type</error>\n");
+      return Command::FAILURE;
+    }
+
+    if (! has_configured_datasource($databaseType, $databaseName)) {
+      $output->writeln("<comment>Creating database configuration for <info>$databaseType:$databaseName</info>...</comment>\n");
+
+      if (Command::SUCCESS !== configure_datasource($input, $output, $databaseType, $databaseName, $root, false)) {
+        return Command::FAILURE;
+      }
+    }
 
     $migrationsDirectory = Path::join($migrationsDirectory, $databaseType, $databaseName);
 
@@ -77,13 +88,6 @@ class MigrationSetup extends Command
       $output->writeln("📂 Migrations directory created successfully\n");
     } else {
       $output->writeln("<comment>The migrations directory already exists</comment>\n");
-    }
-
-    $dbConfig = new DBConfig($input, $output, $databaseName, $databaseType);
-
-    if (Command::SUCCESS !== $dbConfig->load()) {
-      $output->writeln("<error>Failed to load database configuration</error>\n");
-      return Command::FAILURE;
     }
 
     /** @var SQLDatabaseConnectionInterface $database */

--- a/src/Core/WorkspaceManager.php
+++ b/src/Core/WorkspaceManager.php
@@ -89,6 +89,10 @@ class WorkspaceManager
       return Command::FAILURE;
     }
 
+    if (Command::SUCCESS !== $this->materializeTemplateFiles($projectDirectory)) {
+      return Command::FAILURE;
+    }
+
     $description = $this->prompts->text(
       'Description',
       '',
@@ -253,6 +257,24 @@ class WorkspaceManager
   protected function buildDefaultPackageName(Text $projectName): string
   {
     return 'assegaiphp/' . $projectName->kebabCase();
+  }
+
+  protected function materializeTemplateFiles(string $projectDirectory): int
+  {
+    $gitignoreTemplatePath = Path::join($projectDirectory, 'gitignore.stub');
+    $gitignorePath = Path::join($projectDirectory, '.gitignore');
+
+    if (! file_exists($gitignoreTemplatePath)) {
+      $this->output->writeln("<error>\ngitignore.stub template file not found</error>");
+      return Command::FAILURE;
+    }
+
+    if (! rename($gitignoreTemplatePath, $gitignorePath)) {
+      $this->output->writeln("<error>\nFailed to create .gitignore file</error>");
+      return Command::FAILURE;
+    }
+
+    return Command::SUCCESS;
   }
 
   protected function buildDefaultNamespace(string $packageName): string

--- a/src/Installers/DatabaseInstaller.php
+++ b/src/Installers/DatabaseInstaller.php
@@ -269,16 +269,7 @@ class DatabaseInstaller extends AbstractInstaller
 
     protected function resolveWorkspaceNamespace(): string
     {
-        $composerConfig = ComposerManifest::load($this->projectPath);
-        $psr4 = $composerConfig['autoload']['psr-4'] ?? [];
-
-        foreach ($psr4 as $namespace => $directory) {
-            if ($directory === 'src/' || $directory === 'src') {
-                return rtrim((string) $namespace, '\\');
-            }
-        }
-
-        return 'Assegai\\App';
+        return ComposerManifest::resolvePsr4Namespace($this->projectPath);
     }
 
     /**

--- a/src/Util/ComposerManifest.php
+++ b/src/Util/ComposerManifest.php
@@ -42,6 +42,33 @@ class ComposerManifest
     );
   }
 
+  public static function resolvePsr4Namespace(string $workspace, string $fallback = 'Assegai\\App'): string
+  {
+    try {
+      $composerConfig = self::load($workspace);
+    } catch (RuntimeException) {
+      return $fallback;
+    }
+
+    $psr4 = $composerConfig['autoload']['psr-4'] ?? [];
+
+    if (! is_array($psr4)) {
+      return $fallback;
+    }
+
+    foreach ($psr4 as $namespace => $directory) {
+      if (! is_string($directory)) {
+        continue;
+      }
+
+      if ($directory === 'src/' || $directory === 'src') {
+        return rtrim((string) $namespace, '\\');
+      }
+    }
+
+    return $fallback;
+  }
+
   /**
    * @param array<string, mixed> $composerConfig
    * @return array<string, mixed>

--- a/src/Util/ComposerManifest.php
+++ b/src/Util/ComposerManifest.php
@@ -57,16 +57,35 @@ class ComposerManifest
     }
 
     foreach ($psr4 as $namespace => $directory) {
-      if (! is_string($directory)) {
-        continue;
-      }
-
-      if ($directory === 'src/' || $directory === 'src') {
-        return rtrim((string) $namespace, '\\');
+      foreach (self::normalizePsr4Directories($directory) as $candidateDirectory) {
+        if (self::isSourceDirectory($candidateDirectory)) {
+          return rtrim((string) $namespace, '\\');
+        }
       }
     }
 
     return $fallback;
+  }
+
+  /**
+   * @return string[]
+   */
+  private static function normalizePsr4Directories(mixed $directories): array
+  {
+    if (is_string($directories)) {
+      return [$directories];
+    }
+
+    if (! is_array($directories)) {
+      return [];
+    }
+
+    return array_values(array_filter($directories, is_string(...)));
+  }
+
+  private static function isSourceDirectory(string $directory): bool
+  {
+    return rtrim(Path::normalize($directory), '/') === 'src';
   }
 
   /**

--- a/src/Util/Config/ProjectConfig.php
+++ b/src/Util/Config/ProjectConfig.php
@@ -146,7 +146,13 @@ class ProjectConfig implements ConfigInterface
 
   private function resolveDatabaseConfigPath(string $projectPath): ?string
   {
-    foreach (['secure.php', 'local.php', 'dev.php', 'default.php'] as $filename) {
+    $securePath = Path::join($projectPath, 'config', 'secure.php');
+
+    if (file_exists($securePath)) {
+      return $securePath;
+    }
+
+    foreach (['local.php', 'dev.php'] as $filename) {
       $path = Path::join($projectPath, 'config', $filename);
 
       if (file_exists($path)) {
@@ -154,7 +160,24 @@ class ProjectConfig implements ConfigInterface
       }
     }
 
-    return null;
+    return $this->createSecureConfig($projectPath, $securePath) ? $securePath : null;
+  }
+
+  private function createSecureConfig(string $projectPath, string $securePath): bool
+  {
+    $configDirectory = Path::join($projectPath, 'config');
+
+    if (! is_dir($configDirectory) && ! mkdir($configDirectory, 0755, true) && ! is_dir($configDirectory)) {
+      return false;
+    }
+
+    $secureTemplatePath = Path::join(Path::getTemplatesDirectory(), 'config', 'secure.php');
+
+    if (! file_exists($secureTemplatePath)) {
+      return false;
+    }
+
+    return copy($secureTemplatePath, $securePath);
   }
 
   /**

--- a/src/Util/Config/ProjectConfig.php
+++ b/src/Util/Config/ProjectConfig.php
@@ -185,7 +185,39 @@ class ProjectConfig implements ConfigInterface
       $contents
     );
 
+    $defaultDatabases = $this->loadDefaultDatabases($projectPath);
+
+    if ($defaultDatabases !== []) {
+      $contents = upsert_php_array_config_section($contents, 'databases', $defaultDatabases);
+
+      if ($contents === false) {
+        return false;
+      }
+    }
+
     return false !== file_put_contents($securePath, $contents);
+  }
+
+  /**
+   * @return array<string, mixed>
+   */
+  private function loadDefaultDatabases(string $projectPath): array
+  {
+    $defaultPath = Path::join($projectPath, 'config', 'default.php');
+
+    if (! file_exists($defaultPath)) {
+      return [];
+    }
+
+    $defaultConfig = require $defaultPath;
+
+    if (! is_array($defaultConfig)) {
+      return [];
+    }
+
+    $databases = $defaultConfig['databases'] ?? [];
+
+    return is_array($databases) ? $databases : [];
   }
 
   /**

--- a/src/Util/Config/ProjectConfig.php
+++ b/src/Util/Config/ProjectConfig.php
@@ -2,6 +2,7 @@
 
 namespace Assegai\Console\Util\Config;
 
+use Assegai\Console\Util\ComposerManifest;
 use Assegai\Console\Util\Config\Interfaces\ConfigInterface;
 use Assegai\Console\Util\Path;
 use Symfony\Component\Console\Command\Command;
@@ -172,12 +173,19 @@ class ProjectConfig implements ConfigInterface
     }
 
     $secureTemplatePath = Path::join(Path::getTemplatesDirectory(), 'config', 'secure.php');
+    $contents = file_get_contents($secureTemplatePath);
 
-    if (! file_exists($secureTemplatePath)) {
+    if ($contents === false) {
       return false;
     }
 
-    return copy($secureTemplatePath, $securePath);
+    $contents = str_replace(
+      'Assegai\\App',
+      ComposerManifest::resolvePsr4Namespace($projectPath),
+      $contents
+    );
+
+    return false !== file_put_contents($securePath, $contents);
   }
 
   /**

--- a/src/Util/Functions.php
+++ b/src/Util/Functions.php
@@ -1,7 +1,9 @@
 <?php
 
 use Assegai\Console\Core\Database\Enumerations\DatabaseType;
+use Assegai\Console\Prompts\CliPrompt;
 use Assegai\Console\Util\Config\AppConfig;
+use Assegai\Console\Util\Config\ProjectConfig;
 use Assegai\Console\Util\Enumerations\ParameterKey;
 use Assegai\Console\Util\Path;
 use Symfony\Component\Console\Command\Command;
@@ -644,17 +646,269 @@ if (!function_exists('greatest_common_divisor')) {
     }
 }
 
-if (!function_exists('get_datasource_type')) {
-    function get_datasource_type(InputInterface $input, OutputInterface $output, string $optionName = 'database_type'): string|false
+if (!function_exists('get_input_datasource_name')) {
+    function get_input_datasource_name(InputInterface $input, string $optionName = 'database_name'): string
     {
-        return match (true) {
-            $input->hasOption(DatabaseType::MYSQL->value) && $input->getOption(DatabaseType::MYSQL->value) => DatabaseType::MYSQL->value,
-            $input->hasOption(DatabaseType::MARIADB->value) && $input->getOption(DatabaseType::MARIADB->value) => DatabaseType::MARIADB->value,
-            $input->hasOption(DatabaseType::POSTGRESQL->value) && $input->getOption(DatabaseType::POSTGRESQL->value) => DatabaseType::POSTGRESQL->value,
-            $input->hasOption(DatabaseType::SQLITE->value) && $input->getOption(DatabaseType::SQLITE->value) => DatabaseType::SQLITE->value,
-            $input->hasOption(DatabaseType::MSSQL->value) && $input->getOption(DatabaseType::MSSQL->value) => DatabaseType::MSSQL->value,
-            default => $input->getOption($optionName) ?? select("Which type of data source do you want to use?", DatabaseType::toArray())
+        $dataSourceName = null;
+
+        if ($input->hasArgument($optionName)) {
+            $dataSourceName = $input->getArgument($optionName);
+        }
+
+        if ($input->hasOption($optionName)) {
+            $dataSourceName = $input->getOption($optionName);
+        }
+
+        return is_string($dataSourceName) ? trim($dataSourceName) : '';
+    }
+}
+
+if (!function_exists('get_project_database_configurations')) {
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    function get_project_database_configurations(): array
+    {
+        $workingDirectory = Path::getProjectRootPath() ?: Path::getWorkingDirectory() ?: '';
+        $configFilenames = ['secure.php', 'local.php', 'dev.php', 'default.php'];
+        $configPath = null;
+
+        foreach ($configFilenames as $configFilename) {
+            $filename = Path::join($workingDirectory, 'config', $configFilename);
+
+            if (file_exists($filename)) {
+                $configPath = $filename;
+                break;
+            }
+        }
+
+        if (! is_string($configPath)) {
+            return [];
+        }
+
+        $config = require $configPath;
+
+        if (! is_array($config)) {
+            return [];
+        }
+
+        $databases = $config['databases'] ?? [];
+
+        return is_array($databases) ? $databases : [];
+    }
+}
+
+if (!function_exists('get_configured_datasource_type')) {
+    function get_configured_datasource_type(string $dataSourceName): string|false
+    {
+        if ($dataSourceName === '') {
+            return false;
+        }
+
+        $matches = [];
+        $databases = get_project_database_configurations();
+
+        foreach (DatabaseType::toArray() as $databaseType) {
+            $configuredDatabases = $databases[$databaseType] ?? null;
+
+            if (is_array($configuredDatabases) && array_key_exists($dataSourceName, $configuredDatabases)) {
+                $matches[] = $databaseType;
+            }
+        }
+
+        return count($matches) === 1 ? $matches[0] : false;
+    }
+}
+
+if (!function_exists('has_configured_datasource')) {
+    function has_configured_datasource(string $datasourceType, string $dataSourceName): bool
+    {
+        if ($datasourceType === '' || $dataSourceName === '') {
+            return false;
+        }
+
+        $databases = get_project_database_configurations();
+        $configuredDatabases = $databases[$datasourceType] ?? null;
+
+        return is_array($configuredDatabases) && array_key_exists($dataSourceName, $configuredDatabases);
+    }
+}
+
+if (!function_exists('get_datasource_option')) {
+    function get_datasource_option(InputInterface $input, string $optionName): mixed
+    {
+        return $input->hasOption($optionName) ? $input->getOption($optionName) : null;
+    }
+}
+
+if (!function_exists('build_datasource_config')) {
+    /**
+     * @return array<string, mixed>|false
+     */
+    function build_datasource_config(
+        InputInterface $input,
+        OutputInterface $output,
+        string $datasourceType,
+        string $dataSourceName,
+        bool $promptForSqliteStorage = true
+    ): array|false
+    {
+        $prompts = new CliPrompt($input, $output);
+
+        if ($datasourceType === DatabaseType::SQLITE->value) {
+            $path = Path::join('.data', "$dataSourceName.sq3");
+
+            if ($promptForSqliteStorage) {
+                $storageType = $prompts->select('How do you want to store your data?', [
+                    'on-disk' => 'on-disk',
+                    'in-memory' => 'in-memory',
+                    'in-memory (persistent)' => 'in-memory (persistent)',
+                ], 'on-disk');
+
+                $path = match ((string) $storageType) {
+                    'in-memory' => ':memory:',
+                    'in-memory (persistent)' => 'file::memory:?cache=shared',
+                    default => $path,
+                };
+            }
+
+            return ['path' => $path];
+        }
+
+        $defaultHost = match ($datasourceType) {
+            DatabaseType::MYSQL->value => DEFAULT_MYSQL_HOST,
+            DatabaseType::MARIADB->value => DEFAULT_MARIADB_HOST,
+            DatabaseType::POSTGRESQL->value => DEFAULT_POSTGRES_HOST,
+            DatabaseType::MSSQL->value => DEFAULT_MSSQL_HOST,
+            default => '',
         };
+        $defaultPort = match ($datasourceType) {
+            DatabaseType::MYSQL->value => DEFAULT_MYSQL_PORT,
+            DatabaseType::MARIADB->value => DEFAULT_MARIADB_PORT,
+            DatabaseType::POSTGRESQL->value => DEFAULT_POSTGRES_PORT,
+            DatabaseType::MSSQL->value => DEFAULT_MSSQL_PORT,
+            default => 0,
+        };
+        $defaultUser = match ($datasourceType) {
+            DatabaseType::MYSQL->value => DEFAULT_MYSQL_USER,
+            DatabaseType::MARIADB->value => DEFAULT_MARIADB_USER,
+            DatabaseType::POSTGRESQL->value => DEFAULT_POSTGRES_USER,
+            DatabaseType::MSSQL->value => DEFAULT_MSSQL_USER,
+            default => '',
+        };
+
+        if ($defaultHost === '' || $defaultPort === 0 || $defaultUser === '') {
+            return false;
+        }
+
+        $host = get_datasource_option($input, 'host');
+        $port = get_datasource_option($input, 'port');
+        $user = get_datasource_option($input, 'user');
+        $password = get_datasource_option($input, 'password');
+
+        if (! is_scalar($host) || (string) $host === '') {
+            $host = $prompts->text('Host', $defaultHost);
+        }
+
+        if (! is_scalar($port) || (string) $port === '') {
+            $port = $prompts->text('Port', (string) $defaultPort);
+        }
+
+        if (! is_scalar($user) || (string) $user === '') {
+            $user = $prompts->text('User', $defaultUser);
+        }
+
+        if (! is_scalar($password) && $password !== null) {
+            $password = null;
+        }
+
+        if ($password === null || $password === false) {
+            $password = $prompts->password('Password');
+        }
+
+        return [
+            'host' => (string) $host,
+            'port' => (int) $port,
+            'user' => (string) $user,
+            'password' => (string) $password,
+        ];
+    }
+}
+
+if (!function_exists('configure_datasource')) {
+    function configure_datasource(
+        InputInterface $input,
+        OutputInterface $output,
+        string $datasourceType,
+        string $dataSourceName,
+        ?string $projectPath = null,
+        bool $promptForSqliteStorage = true
+    ): int
+    {
+        if (! DatabaseType::isValid($datasourceType) || $dataSourceName === '') {
+            $output->writeln('<error>Invalid database configuration.</error>');
+            return Command::FAILURE;
+        }
+
+        $databaseConfig = build_datasource_config($input, $output, $datasourceType, $dataSourceName, $promptForSqliteStorage);
+
+        if ($databaseConfig === false) {
+            $output->writeln('<error>Failed to build database configuration.</error>');
+            return Command::FAILURE;
+        }
+
+        $projectPath ??= Path::getProjectRootPath() ?: Path::getWorkingDirectory() ?: '';
+        $projectConfig = new ProjectConfig($input, $output);
+
+        $bytes = $projectConfig->updateDatabaseConfig([
+            'databases' => [
+                $datasourceType => [
+                    $dataSourceName => $databaseConfig,
+                ],
+            ],
+        ], $projectPath);
+
+        if ($bytes === false) {
+            $output->writeln('<error>Failed to save database configuration.</error>');
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+}
+
+if (!function_exists('get_datasource_type')) {
+    function get_datasource_type(
+        InputInterface $input,
+        OutputInterface $output,
+        string $optionName = 'database_type',
+        string $databaseNameOption = 'database_name'
+    ): string|false
+    {
+        foreach (DatabaseType::toArray() as $databaseType) {
+            if ($input->hasOption($databaseType) && $input->getOption($databaseType)) {
+                return $databaseType;
+            }
+        }
+
+        if ($input->hasOption($optionName)) {
+            $optionValue = $input->getOption($optionName);
+
+            if (is_string($optionValue) && $optionValue !== '') {
+                return $optionValue;
+            }
+        }
+
+        $configuredType = get_configured_datasource_type(get_input_datasource_name($input, $databaseNameOption));
+
+        if ($configuredType) {
+            return $configuredType;
+        }
+
+        $prompts = new CliPrompt($input, $output);
+        $selectedType = $prompts->select("Which type of data source do you want to use?", DatabaseType::toArray());
+
+        return is_string($selectedType) ? $selectedType : false;
     }
 }
 

--- a/templates/gitignore.stub
+++ b/templates/gitignore.stub
@@ -9,7 +9,6 @@
 /config/local*.php
 /config/dev*.php
 /config/secure*.php
-!/config/secure.php
 /.data/
 /logs/
 

--- a/tests/Feature/MigrationSetupTest.php
+++ b/tests/Feature/MigrationSetupTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use Assegai\Console\Commands\Migration\MigrationSetup;
+use Assegai\Console\Core\Database\Enumerations\DatabaseType;
+use Assegai\Console\Prompts\CliPrompt;
+use Assegai\Console\Util\Enumerations\ParameterKey;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @param array<string, array<string, mixed>> $databases
+ */
+function createMigrationSetupWorkspace(array $databases): string
+{
+  $workspace = sys_get_temp_dir() . '/' . uniqid('migration-setup-', true);
+
+  if (! mkdir($workspace . '/config', 0755, true) && ! is_dir($workspace . '/config')) {
+    throw new RuntimeException("Failed to create test workspace: $workspace");
+  }
+
+  file_put_contents($workspace . '/composer.json', json_encode([
+    'autoload' => [
+      'psr-4' => [
+        'Acme\\BlogApi\\' => 'src/',
+      ],
+    ],
+  ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+  file_put_contents($workspace . '/assegai.json', "{}\n");
+  file_put_contents($workspace . '/bootstrap.php', "<?php\n");
+
+  $config = array_to_string(['databases' => $databases]);
+
+  if ($config === false) {
+    throw new RuntimeException('Failed to create migration setup config.');
+  }
+
+  file_put_contents($workspace . '/config/secure.php', "<?php\n\nreturn $config;\n");
+
+  return $workspace;
+}
+
+function deleteMigrationSetupWorkspace(string $directory): void
+{
+  if (! is_dir($directory)) {
+    return;
+  }
+
+  $items = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::CHILD_FIRST
+  );
+
+  foreach ($items as $item) {
+    if ($item->isDir()) {
+      rmdir($item->getPathname());
+      continue;
+    }
+
+    unlink($item->getPathname());
+  }
+
+  rmdir($directory);
+}
+
+describe('migration:setup', function () {
+  it('uses the configured datasource type without prompting', function () {
+    $workspace = createMigrationSetupWorkspace([
+      DatabaseType::SQLITE->value => [
+        'blog_api' => [
+          'path' => '.data/blog_api.sq3',
+        ],
+      ],
+    ]);
+    $previousWorkingDirectory = getcwd();
+
+    if ($previousWorkingDirectory === false) {
+      throw new RuntimeException('Failed to determine the current working directory.');
+    }
+
+    chdir($workspace);
+
+    try {
+      $tester = new CommandTester(new MigrationSetup());
+      $status = $tester->execute([ParameterKey::DB_NAME->value => 'blog_api'], ['interactive' => false]);
+
+      expect($status)->toBe(Command::SUCCESS);
+      expect($tester->getDisplay())->not->toContain('Which type of data source do you want to use?');
+      expect(file_exists($workspace . '/migrations/sqlite/blog_api'))->toBeTrue();
+      expect(file_exists($workspace . '/.data/blog_api.sq3'))->toBeTrue();
+    } finally {
+      chdir($previousWorkingDirectory);
+      deleteMigrationSetupWorkspace($workspace);
+    }
+  });
+
+  it('creates sqlite config for a missing datasource when the type is explicit', function () {
+    $workspace = createMigrationSetupWorkspace([]);
+    $previousWorkingDirectory = getcwd();
+
+    if ($previousWorkingDirectory === false) {
+      throw new RuntimeException('Failed to determine the current working directory.');
+    }
+
+    chdir($workspace);
+
+    try {
+      $tester = new CommandTester(new MigrationSetup());
+      $status = $tester->execute([
+        ParameterKey::DB_NAME->value => 'blog_api',
+        '--' . DatabaseType::SQLITE->value => true,
+      ], ['interactive' => false]);
+
+      $config = require $workspace . '/config/secure.php';
+
+      expect($status)->toBe(Command::SUCCESS);
+      expect($config['databases']['sqlite']['blog_api']['path'])->toBe('.data/blog_api.sq3');
+      expect(file_exists($workspace . '/migrations/sqlite/blog_api'))->toBeTrue();
+      expect(file_exists($workspace . '/.data/blog_api.sq3'))->toBeTrue();
+    } finally {
+      chdir($previousWorkingDirectory);
+      deleteMigrationSetupWorkspace($workspace);
+    }
+  });
+
+  it('asks for type only when the datasource is missing and then creates config', function () {
+    $workspace = createMigrationSetupWorkspace([]);
+    $previousWorkingDirectory = getcwd();
+
+    if ($previousWorkingDirectory === false) {
+      throw new RuntimeException('Failed to determine the current working directory.');
+    }
+
+    chdir($workspace);
+
+    try {
+      CliPrompt::fake([
+        'select' => [DatabaseType::SQLITE->value],
+      ]);
+
+      $tester = new CommandTester(new MigrationSetup());
+      $status = $tester->execute([ParameterKey::DB_NAME->value => 'blog_api'], ['interactive' => true]);
+      $config = require $workspace . '/config/secure.php';
+
+      expect($status)->toBe(Command::SUCCESS);
+      expect($config['databases']['sqlite']['blog_api']['path'])->toBe('.data/blog_api.sq3');
+      expect(file_exists($workspace . '/migrations/sqlite/blog_api'))->toBeTrue();
+      expect(file_exists($workspace . '/.data/blog_api.sq3'))->toBeTrue();
+    } finally {
+      CliPrompt::flushFake();
+      chdir($previousWorkingDirectory);
+      deleteMigrationSetupWorkspace($workspace);
+    }
+  });
+});

--- a/tests/Feature/ProjectConfigDatabaseUpdateTest.php
+++ b/tests/Feature/ProjectConfigDatabaseUpdateTest.php
@@ -136,6 +136,63 @@ describe('ProjectConfig database updates', function () {
     }
   });
 
+  it('preserves databases from default config when recreating secure config', function () {
+    $workspace = createProjectConfigWorkspace();
+
+    try {
+      $secureConfigPath = $workspace . '/config/secure.php';
+      $defaultConfigPath = $workspace . '/config/default.php';
+      unlink($secureConfigPath);
+      writeProjectConfigComposer($workspace);
+
+      $defaultConfigContents = file_get_contents($defaultConfigPath) ?: '';
+      $defaultConfigContents = upsert_php_array_config_section($defaultConfigContents, 'databases', [
+        'sqlite' => [
+          'existing_blog' => [
+            'path' => '.data/existing_blog.sq3',
+          ],
+        ],
+        'mysql' => [
+          'legacy_app' => [
+            'host' => '127.0.0.1',
+            'user' => 'root',
+            'password' => 'legacy-secret',
+            'port' => 3306,
+          ],
+        ],
+      ]);
+
+      if ($defaultConfigContents === false) {
+        throw new RuntimeException('Failed to update default config fixture.');
+      }
+
+      file_put_contents($defaultConfigPath, $defaultConfigContents);
+
+      $projectConfig = new ProjectConfig(new MockInput(), new MockOutput());
+      $bytes = $projectConfig->updateDatabaseConfig([
+        'databases' => [
+          'sqlite' => [
+            'new_blog' => [
+              'path' => '.data/new_blog.sq3',
+            ],
+          ],
+        ],
+      ], $workspace);
+
+      expect($bytes)->not->toBeFalse();
+
+      $secureConfig = require $secureConfigPath;
+
+      expect($secureConfig['databases']['sqlite']['existing_blog']['path'])->toBe('.data/existing_blog.sq3');
+      expect($secureConfig['databases']['mysql']['legacy_app']['password'])->toBe('legacy-secret');
+      expect($secureConfig['databases']['sqlite']['new_blog']['path'])->toBe('.data/new_blog.sq3');
+      expect($secureConfig['authentication']['jwt']['entityClassName'])
+        ->toBe('Acme\\ClonedApp\\Users\\Entities\\UserEntity');
+    } finally {
+      deleteProjectConfigWorkspace($workspace);
+    }
+  });
+
   it('rewrites recreated secure config namespaces from composer PSR-4 directory arrays', function () {
     $workspace = createProjectConfigWorkspace();
 

--- a/tests/Feature/ProjectConfigDatabaseUpdateTest.php
+++ b/tests/Feature/ProjectConfigDatabaseUpdateTest.php
@@ -25,16 +25,20 @@ function createProjectConfigWorkspace(): string
   return $workspace;
 }
 
-function writeProjectConfigComposer(string $workspace, string $namespace = 'Acme\\ClonedApp\\'): void
+/**
+ * @param string|string[] $directories
+ */
+function writeProjectConfigComposer(string $workspace, string $namespace = 'Acme\\ClonedApp\\', string|array $directories = 'src/'): void
 {
   file_put_contents($workspace . '/composer.json', json_encode([
     'autoload' => [
       'psr-4' => [
-        $namespace => 'src/',
+        $namespace => $directories,
       ],
     ],
   ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 }
+
 
 function deleteProjectConfigWorkspace(string $directory): void
 {
@@ -127,6 +131,36 @@ describe('ProjectConfig database updates', function () {
       expect($secureConfig['authentication']['jwt']['entityClassName'])
         ->toBe('Acme\\ClonedApp\\Users\\Entities\\UserEntity');
       expect($defaultConfig['databases'] ?? null)->toBeNull();
+    } finally {
+      deleteProjectConfigWorkspace($workspace);
+    }
+  });
+
+  it('rewrites recreated secure config namespaces from composer PSR-4 directory arrays', function () {
+    $workspace = createProjectConfigWorkspace();
+
+    try {
+      $secureConfigPath = $workspace . '/config/secure.php';
+      unlink($secureConfigPath);
+      writeProjectConfigComposer($workspace, 'Acme\\ArrayApp\\', ['generated/', 'src/']);
+      $projectConfig = new ProjectConfig(new MockInput(), new MockOutput());
+
+      $bytes = $projectConfig->updateDatabaseConfig([
+        'databases' => [
+          'sqlite' => [
+            'array_app' => [
+              'path' => '.data/array_app.sq3',
+            ],
+          ],
+        ],
+      ], $workspace);
+
+      expect($bytes)->not->toBeFalse();
+
+      $secureConfig = require $secureConfigPath;
+
+      expect($secureConfig['authentication']['jwt']['entityClassName'])
+        ->toBe('Acme\\ArrayApp\\Users\\Entities\\UserEntity');
     } finally {
       deleteProjectConfigWorkspace($workspace);
     }

--- a/tests/Feature/ProjectConfigDatabaseUpdateTest.php
+++ b/tests/Feature/ProjectConfigDatabaseUpdateTest.php
@@ -81,6 +81,43 @@ describe('ProjectConfig database updates', function () {
     }
   });
 
+  it('creates secure config for database updates instead of writing to shared defaults', function () {
+    $workspace = createProjectConfigWorkspace();
+
+    try {
+      $secureConfigPath = $workspace . '/config/secure.php';
+      $defaultConfigPath = $workspace . '/config/default.php';
+      unlink($secureConfigPath);
+      $defaultConfigBefore = file_get_contents($defaultConfigPath) ?: '';
+      $projectConfig = new ProjectConfig(new MockInput(), new MockOutput());
+
+      $bytes = $projectConfig->updateDatabaseConfig([
+        'databases' => [
+          'mysql' => [
+            'cloned_app' => [
+              'host' => '127.0.0.1',
+              'user' => 'root',
+              'password' => 'secret',
+              'port' => 3306,
+            ],
+          ],
+        ],
+      ], $workspace);
+
+      expect($bytes)->not->toBeFalse();
+      expect(file_exists($secureConfigPath))->toBeTrue();
+      expect(file_get_contents($defaultConfigPath))->toBe($defaultConfigBefore);
+
+      $secureConfig = require $secureConfigPath;
+      $defaultConfig = require $defaultConfigPath;
+
+      expect($secureConfig['databases']['mysql']['cloned_app']['password'])->toBe('secret');
+      expect($defaultConfig['databases'] ?? null)->toBeNull();
+    } finally {
+      deleteProjectConfigWorkspace($workspace);
+    }
+  });
+
   it('writes sqlite paths without escaping forward slashes', function () {
     $workspace = createProjectConfigWorkspace();
 

--- a/tests/Feature/ProjectConfigDatabaseUpdateTest.php
+++ b/tests/Feature/ProjectConfigDatabaseUpdateTest.php
@@ -25,6 +25,17 @@ function createProjectConfigWorkspace(): string
   return $workspace;
 }
 
+function writeProjectConfigComposer(string $workspace, string $namespace = 'Acme\\ClonedApp\\'): void
+{
+  file_put_contents($workspace . '/composer.json', json_encode([
+    'autoload' => [
+      'psr-4' => [
+        $namespace => 'src/',
+      ],
+    ],
+  ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+}
+
 function deleteProjectConfigWorkspace(string $directory): void
 {
   if (! is_dir($directory)) {
@@ -89,6 +100,7 @@ describe('ProjectConfig database updates', function () {
       $defaultConfigPath = $workspace . '/config/default.php';
       unlink($secureConfigPath);
       $defaultConfigBefore = file_get_contents($defaultConfigPath) ?: '';
+      writeProjectConfigComposer($workspace);
       $projectConfig = new ProjectConfig(new MockInput(), new MockOutput());
 
       $bytes = $projectConfig->updateDatabaseConfig([
@@ -112,6 +124,8 @@ describe('ProjectConfig database updates', function () {
       $defaultConfig = require $defaultConfigPath;
 
       expect($secureConfig['databases']['mysql']['cloned_app']['password'])->toBe('secret');
+      expect($secureConfig['authentication']['jwt']['entityClassName'])
+        ->toBe('Acme\\ClonedApp\\Users\\Entities\\UserEntity');
       expect($defaultConfig['databases'] ?? null)->toBeNull();
     } finally {
       deleteProjectConfigWorkspace($workspace);

--- a/tests/Unit/ComposerManifestTest.php
+++ b/tests/Unit/ComposerManifestTest.php
@@ -62,6 +62,23 @@ describe('ComposerManifest', function () {
     }
   });
 
+  it('resolves the workspace source namespace from composer PSR-4 directory arrays', function () {
+    $workspace = createComposerManifestWorkspace([
+      'autoload' => [
+        'psr-4' => [
+          'Acme\\Shared\\' => ['lib/', 'packages/shared/'],
+          'Acme\\ArrayApp\\' => ['generated/', './src/'],
+        ],
+      ],
+    ]);
+
+    try {
+      expect(ComposerManifest::resolvePsr4Namespace($workspace))->toBe('Acme\\ArrayApp');
+    } finally {
+      deleteComposerManifestWorkspace($workspace);
+    }
+  });
+
   it('falls back when composer metadata cannot resolve a source namespace', function () {
     $workspace = createComposerManifestWorkspace([
       'autoload' => [

--- a/tests/Unit/ComposerManifestTest.php
+++ b/tests/Unit/ComposerManifestTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Assegai\Console\Util\ComposerManifest;
+
+/**
+ * @param array<string, mixed> $composerConfig
+ */
+function createComposerManifestWorkspace(array $composerConfig): string
+{
+  $workspace = sys_get_temp_dir() . '/' . uniqid('composer-manifest-', true);
+
+  if (! mkdir($workspace, 0755, true) && ! is_dir($workspace)) {
+    throw new RuntimeException("Failed to create test workspace: $workspace");
+  }
+
+  file_put_contents(
+    $workspace . '/composer.json',
+    json_encode($composerConfig, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES) . PHP_EOL
+  );
+
+  return $workspace;
+}
+
+function deleteComposerManifestWorkspace(string $directory): void
+{
+  if (! is_dir($directory)) {
+    return;
+  }
+
+  $items = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::CHILD_FIRST
+  );
+
+  foreach ($items as $item) {
+    if ($item->isDir()) {
+      rmdir($item->getPathname());
+      continue;
+    }
+
+    unlink($item->getPathname());
+  }
+
+  rmdir($directory);
+}
+
+describe('ComposerManifest', function () {
+  it('resolves the workspace source namespace from composer autoload metadata', function () {
+    $workspace = createComposerManifestWorkspace([
+      'autoload' => [
+        'psr-4' => [
+          'Acme\\Shared\\' => 'lib/',
+          'Acme\\ClonedApp\\' => 'src/',
+        ],
+      ],
+    ]);
+
+    try {
+      expect(ComposerManifest::resolvePsr4Namespace($workspace))->toBe('Acme\\ClonedApp');
+    } finally {
+      deleteComposerManifestWorkspace($workspace);
+    }
+  });
+
+  it('falls back when composer metadata cannot resolve a source namespace', function () {
+    $workspace = createComposerManifestWorkspace([
+      'autoload' => [
+        'psr-4' => [
+          'Acme\\Shared\\' => 'lib/',
+        ],
+      ],
+    ]);
+
+    try {
+      expect(ComposerManifest::resolvePsr4Namespace($workspace))->toBe('Assegai\\App');
+      expect(ComposerManifest::resolvePsr4Namespace('/missing-workspace', 'Fallback\\App'))->toBe('Fallback\\App');
+    } finally {
+      deleteComposerManifestWorkspace($workspace);
+    }
+  });
+});

--- a/tests/Unit/DataSourceTypeInferenceTest.php
+++ b/tests/Unit/DataSourceTypeInferenceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use Assegai\Console\Commands\Database\DatabaseSetup;
+use Assegai\Console\Core\Database\Enumerations\DatabaseType;
+use Assegai\Console\Tests\Mocks\MockInput;
+use Assegai\Console\Tests\Mocks\MockOutput;
+use Assegai\Console\Util\Enumerations\ParameterKey;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @param array<string, array<string, mixed>> $databases
+ */
+function createDataSourceTypeInferenceWorkspace(array $databases): string
+{
+  $workspace = sys_get_temp_dir() . '/' . uniqid('datasource-type-inference-', true);
+
+  if (! mkdir($workspace . '/config', 0755, true) && ! is_dir($workspace . '/config')) {
+    throw new RuntimeException("Failed to create test workspace: $workspace");
+  }
+
+  file_put_contents($workspace . '/composer.json', json_encode([
+    'autoload' => [
+      'psr-4' => [
+        'Acme\\BlogApi\\' => 'src/',
+      ],
+    ],
+  ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+  file_put_contents($workspace . '/assegai.json', "{}\n");
+  file_put_contents($workspace . '/bootstrap.php', "<?php\n");
+  file_put_contents($workspace . '/config/secure.php', "<?php\n\nreturn " . var_export(['databases' => $databases], true) . ";\n");
+
+  return $workspace;
+}
+
+function deleteDataSourceTypeInferenceWorkspace(string $directory): void
+{
+  if (! is_dir($directory)) {
+    return;
+  }
+
+  $items = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+    RecursiveIteratorIterator::CHILD_FIRST
+  );
+
+  foreach ($items as $item) {
+    if ($item->isDir()) {
+      rmdir($item->getPathname());
+      continue;
+    }
+
+    unlink($item->getPathname());
+  }
+
+  rmdir($directory);
+}
+
+describe('datasource type inference', function () {
+  it('infers the datasource type from a configured database name argument', function () {
+    $workspace = createDataSourceTypeInferenceWorkspace([
+      DatabaseType::SQLITE->value => [
+        'blog_api' => [
+          'path' => '.data/blog_api.sq3',
+        ],
+      ],
+    ]);
+    $previousWorkingDirectory = getcwd();
+
+    if ($previousWorkingDirectory === false) {
+      throw new RuntimeException('Failed to determine the current working directory.');
+    }
+
+    chdir($workspace);
+
+    try {
+      $input = new MockInput([ParameterKey::DB_NAME->value => 'blog_api']);
+      $type = get_datasource_type($input, new MockOutput());
+
+      expect($type)->toBe(DatabaseType::SQLITE->value);
+    } finally {
+      chdir($previousWorkingDirectory);
+      deleteDataSourceTypeInferenceWorkspace($workspace);
+    }
+  });
+
+  it('infers the datasource type from a configured database name option', function () {
+    $workspace = createDataSourceTypeInferenceWorkspace([
+      DatabaseType::POSTGRESQL->value => [
+        'analytics' => [
+          'host' => '127.0.0.1',
+        ],
+      ],
+    ]);
+    $previousWorkingDirectory = getcwd();
+
+    if ($previousWorkingDirectory === false) {
+      throw new RuntimeException('Failed to determine the current working directory.');
+    }
+
+    chdir($workspace);
+
+    try {
+      $input = new MockInput([], ['database' => 'analytics']);
+      $type = get_datasource_type($input, new MockOutput(), ParameterKey::DB_TYPE->value, 'database');
+
+      expect($type)->toBe(DatabaseType::POSTGRESQL->value);
+    } finally {
+      chdir($previousWorkingDirectory);
+      deleteDataSourceTypeInferenceWorkspace($workspace);
+    }
+  });
+
+  it('sets up a configured sqlite database without prompting for a datasource type', function () {
+    $workspace = createDataSourceTypeInferenceWorkspace([
+      DatabaseType::SQLITE->value => [
+        'blog_api' => [
+          'path' => '.data/blog_api.sq3',
+        ],
+      ],
+    ]);
+    $previousWorkingDirectory = getcwd();
+
+    if ($previousWorkingDirectory === false) {
+      throw new RuntimeException('Failed to determine the current working directory.');
+    }
+
+    chdir($workspace);
+
+    try {
+      $commandTester = new CommandTester(new DatabaseSetup());
+      $status = $commandTester->execute([ParameterKey::DB_NAME->value => 'blog_api'], ['interactive' => false]);
+
+      expect($status)->toBe(Command::SUCCESS);
+      expect($commandTester->getDisplay())->not->toContain('Which type of data source do you want to use?');
+      expect(file_exists($workspace . '/.data/blog_api.sq3'))->toBeTrue();
+    } finally {
+      chdir($previousWorkingDirectory);
+      deleteDataSourceTypeInferenceWorkspace($workspace);
+    }
+  });
+
+  it('does not infer a type when a configured database name is ambiguous', function () {
+    $workspace = createDataSourceTypeInferenceWorkspace([
+      DatabaseType::MYSQL->value => ['shared' => []],
+      DatabaseType::SQLITE->value => ['shared' => ['path' => '.data/shared.sq3']],
+    ]);
+    $previousWorkingDirectory = getcwd();
+
+    if ($previousWorkingDirectory === false) {
+      throw new RuntimeException('Failed to determine the current working directory.');
+    }
+
+    chdir($workspace);
+
+    try {
+      expect(get_configured_datasource_type('shared'))->toBeFalse();
+    } finally {
+      chdir($previousWorkingDirectory);
+      deleteDataSourceTypeInferenceWorkspace($workspace);
+    }
+  });
+});

--- a/tests/Unit/PostgreSQLInstallerTest.php
+++ b/tests/Unit/PostgreSQLInstallerTest.php
@@ -64,12 +64,14 @@ describe('PostgreSQL installer', function () {
 
       expect($installer->install())->toBe(Command::SUCCESS);
 
-      $config = require $workspace . '/config/default.php';
+      $secureConfig = require $workspace . '/config/secure.php';
+      $defaultConfig = require $workspace . '/config/default.php';
 
-      expect($config['databases']['pgsql']['cinema_hub']['host'])->toBe('127.0.0.1');
-      expect($config['databases']['pgsql']['cinema_hub']['user'])->toBe('postgres');
-      expect($config['databases']['pgsql']['cinema_hub']['password'])->toBe('secret');
-      expect($config['databases'])->not->toHaveKey('postgresql');
+      expect($secureConfig['databases']['pgsql']['cinema_hub']['host'])->toBe('127.0.0.1');
+      expect($secureConfig['databases']['pgsql']['cinema_hub']['user'])->toBe('postgres');
+      expect($secureConfig['databases']['pgsql']['cinema_hub']['password'])->toBe('secret');
+      expect($secureConfig['databases'])->not->toHaveKey('postgresql');
+      expect($defaultConfig['databases'] ?? null)->toBeNull();
     } finally {
       CliPrompt::flushFake();
       deleteInstallerWorkspace($workspace);

--- a/tests/Unit/WorkspaceManagerTest.php
+++ b/tests/Unit/WorkspaceManagerTest.php
@@ -128,6 +128,8 @@ describe('Workspace manager', function () {
       $readme = file_get_contents($readmeFilename) ?: '';
       $agentsFilename = $workspace . '/my-blog-api/AGENTS.md';
       $agents = file_get_contents($agentsFilename) ?: '';
+      $gitignoreFilename = $workspace . '/my-blog-api/.gitignore';
+      $gitignore = file_get_contents($gitignoreFilename) ?: '';
       $secureConfigFilename = $workspace . '/my-blog-api/config/secure.php';
       $secureConfig = file_get_contents($secureConfigFilename) ?: '';
 
@@ -142,6 +144,10 @@ describe('Workspace manager', function () {
       expect($agents)->toContain('Guidance for coding agents working in this AssegaiPHP application.');
       expect($agents)->toContain('Prefer the Assegai CLI generators');
       expect($agents)->toContain('composer test');
+      expect(file_exists($gitignoreFilename))->toBeTrue();
+      expect(file_exists($workspace . '/my-blog-api/gitignore.stub'))->toBeFalse();
+      expect($gitignore)->toContain('/config/secure*.php');
+      expect($gitignore)->not->toContain('!/config/secure.php');
       expect($secureConfig)->toContain('Acme\\BlogApi\\Users\\Entities\\UserEntity::class');
     } finally {
       CliPrompt::flushFake();


### PR DESCRIPTION
This pull request introduces logic to handle the creation of the `.gitignore` file from a template during workspace initialization, and updates tests to verify this behavior. The main focus is on ensuring the `.gitignore` file is properly materialized from a template (`gitignore.stub`) and that the template is removed after use. Additionally, the `.gitignore` template itself has been updated.

File materialization and workflow changes:

* Added a new `materializeTemplateFiles` method in `WorkspaceManager` to rename `gitignore.stub` to `.gitignore` in the project directory, with error handling if the template is missing or renaming fails. This method is now called during project initialization. [[1]](diffhunk://#diff-5318b983599050d2d1cf4da24e56c71d20b5541faefabf36552071bf772bf25eR92-R95) [[2]](diffhunk://#diff-5318b983599050d2d1cf4da24e56c71d20b5541faefabf36552071bf772bf25eR262-R279)

Template and test updates:

* Renamed the template file from `.gitignore` to `gitignore.stub` and updated its contents to remove the line `!/config/secure.php`.
* Updated unit tests to:
  - Check that `.gitignore` exists and `gitignore.stub` does not after initialization.
  - Verify `.gitignore` contains `/config/secure*.php` and does not contain `!/config/secure.php`. [[1]](diffhunk://#diff-518b69f3629baf55e3414091445c62a1f2bc3141808c6247529ef815f665d5fdR131-R132) [[2]](diffhunk://#diff-518b69f3629baf55e3414091445c62a1f2bc3141808c6247529ef815f665d5fdR147-R150)