### PR TITLE
Develop

### DIFF
--- a/docs/releases/0.9.3.md
+++ b/docs/releases/0.9.3.md
@@ -1,0 +1,53 @@
+# Assegai Console 0.9.3 Release Notes
+
+Released: 2026-06-05
+
+## Overview
+
+Assegai Console 0.9.3 focuses on safer project scaffolding and more reliable database and migration setup flows. It improves how generated projects handle local secure configuration, avoids unnecessary prompts when an existing datasource can be inferred, and adds regression coverage for the project setup paths that affect new applications and cloned workspaces.
+
+## Highlights
+
+### Safer secure configuration handling
+
+- Generated projects now receive `.gitignore` from a scaffold template named `gitignore.stub`, which is renamed during project creation.
+- The generated `.gitignore` keeps `config/secure.php` ignored without requiring a negated tracking rule in the template.
+- Database configuration writes now recreate `config/secure.php` when it is missing instead of falling back to tracked shared config.
+- Recreated secure config files preserve any database entries already present in `config/default.php`, so adding a new datasource does not hide existing configured databases.
+
+### Better project namespace detection
+
+- Secure config recreation now resolves the project namespace from `composer.json` before writing framework auth defaults.
+- PSR-4 namespace detection now supports Composer's string and array directory forms, including mappings such as:
+
+```json
+{
+  "autoload": {
+    "psr-4": {
+      "Acme\\App\\": ["src/"]
+    }
+  }
+}
+```
+
+### Smarter database and migration setup
+
+- `database:setup` now infers the datasource type from existing configuration when the requested database name is already configured.
+- `migration:setup` uses the same inference behavior and only asks for a datasource type when the CLI truly lacks enough information.
+- Missing datasource configuration can now be created as part of migration setup instead of forcing users through a separate local repair step.
+- `migration:create --database` participates in datasource type inference, so named database workflows stay consistent across setup and generation commands.
+- `database:configure` now uses the shared datasource configuration writer used by migration setup.
+
+### Starter project guidance
+
+- New project scaffolds now include an `AGENTS.md` file with guidance for coding agents working inside an AssegaiPHP application.
+
+## Upgrade Notes
+
+- Existing projects do not need to commit `config/secure.php`. It remains the local, ignored override file for secrets and machine-specific database settings.
+- If an older project has database entries only in `config/default.php`, the console now carries those entries into a newly recreated `config/secure.php` before writing new datasource settings.
+- Projects using PSR-4 array mappings in Composer are now supported by namespace-sensitive config recreation.
+
+## Validation
+
+This release adds regression coverage for secure config recreation, default database preservation, PSR-4 namespace resolution, datasource type inference, and migration setup configuration writes.

--- a/docs/releases/0.9.4.md
+++ b/docs/releases/0.9.4.md
@@ -1,0 +1,25 @@
+# Assegai Console 0.9.4 Release Notes
+
+Released: 2026-06-07
+
+## Overview
+
+Assegai Console 0.9.4 tightens the public CLI command surface. Internal release-maintenance tooling remains available to the framework repository, but it is no longer registered in the user-facing `assegai` application.
+
+## Highlights
+
+### Public command list cleanup
+
+- Removed `updates:scaffold` from the public `assegai` command list.
+- Kept the update scaffold helper available internally for release authors and repository tests.
+- Added regression coverage so internal release tooling cannot accidentally reappear through `ApplicationFactory`.
+
+## Upgrade Notes
+
+- Application developers should not see any behavior change in normal project workflows.
+- The public `updates` command group is no longer shown by `assegai list`.
+- Release authors can still exercise the scaffold helper directly in the console repository when preparing update-advisor data and upgrade-note drafts.
+
+## Validation
+
+This release verifies that `updates:scaffold` is absent from the public CLI while the internal scaffold command still works under direct test coverage.

--- a/src/ApplicationFactory.php
+++ b/src/ApplicationFactory.php
@@ -17,7 +17,6 @@ use Assegai\Console\Commands\Schematic\SchematicList;
 use Assegai\Console\Commands\Serve;
 use Assegai\Console\Commands\Test;
 use Assegai\Console\Commands\Update;
-use Assegai\Console\Commands\Updates\ScaffoldUpdateGuide;
 use Assegai\Console\Commands\Version;
 use Assegai\Console\Commands\WebComponents\BuildWebComponents;
 use Assegai\Console\Commands\WebComponents\ListWebComponents;
@@ -70,7 +69,6 @@ class ApplicationFactory
       new Serve(),
       new Test(),
       new Update(),
-      new ScaffoldUpdateGuide(),
       new Version(),
       new BuildWebComponents(),
       new ListWebComponents(),

--- a/tests/Feature/PackageCommandDiscoveryTest.php
+++ b/tests/Feature/PackageCommandDiscoveryTest.php
@@ -88,6 +88,12 @@ function removePackageDiscoveryWorkspace(string $directory): void
 }
 
 describe('ApplicationFactory package command discovery', function () {
+  it('does not expose internal release tooling as public commands', function () {
+    $application = ApplicationFactory::create(sys_get_temp_dir());
+
+    expect($application->has('updates:scaffold'))->toBeFalse();
+  });
+
   it('loads command classes declared by installed package manifests', function () {
     $workspace = createPackageDiscoveryWorkspace();
 

--- a/tests/Feature/PackageCommandDiscoveryTest.php
+++ b/tests/Feature/PackageCommandDiscoveryTest.php
@@ -89,9 +89,19 @@ function removePackageDiscoveryWorkspace(string $directory): void
 
 describe('ApplicationFactory package command discovery', function () {
   it('does not expose internal release tooling as public commands', function () {
-    $application = ApplicationFactory::create(sys_get_temp_dir());
+    $workspace = sys_get_temp_dir() . '/' . uniqid('command-surface-', true);
 
-    expect($application->has('updates:scaffold'))->toBeFalse();
+    if (!mkdir($workspace, 0755, true) && !is_dir($workspace)) {
+      throw new RuntimeException("Failed to create test workspace: $workspace");
+    }
+
+    try {
+      $application = ApplicationFactory::create($workspace);
+
+      expect($application->has('updates:scaffold'))->toBeFalse();
+    } finally {
+      removePackageDiscoveryWorkspace($workspace);
+    }
   });
 
   it('loads command classes declared by installed package manifests', function () {


### PR DESCRIPTION
This pull request improves the safety and reliability of project scaffolding and database setup in Assegai Console, and ensures that internal release tooling is not exposed as public commands. It also introduces better handling of secure configuration files and project namespaces, and adds regression test coverage for these areas.

**Project scaffolding and configuration improvements:**

* Generated projects now use a safer `.gitignore` template (`gitignore.stub`), ensuring `config/secure.php` is always ignored and handled locally, and secure config files are recreated as needed while preserving existing database settings.
* The process for recreating secure config files now detects the project namespace from `composer.json`, with improved support for PSR-4 mappings in both string and array forms.

**Database and migration setup enhancements:**

* `database:setup` and `migration:setup` commands now infer datasource types from existing configuration, reducing unnecessary prompts, and allow missing datasource configuration to be created during migration setup.
* The `migration:create --database` command and `database:configure` now participate in and use the improved datasource inference and shared configuration writing logic.

**Internal tooling and validation:**

* The internal `ScaffoldUpdateGuide` command has been removed from the list of public CLI commands, ensuring it is not exposed to users. [[1]](diffhunk://#diff-07208870d6cc67b0d5873f1dd53712b23a42bd9e7b9fd7020caeba18e8bb8694L20) [[2]](diffhunk://#diff-07208870d6cc67b0d5873f1dd53712b23a42bd9e7b9fd7020caeba18e8bb8694L73)
* A new regression test ensures that internal release tooling like `updates:scaffold` is not available as a public command.

**Documentation and guidance:**

* Added detailed release notes for version 0.9.3, summarizing all the above improvements and providing upgrade notes and validation coverage.
* New project scaffolds now include an `AGENTS.md` file to guide developers working within AssegaiPHP applications.