### PR TITLE
Add release notes for Assegai Console 0.9.5 migration improvements

### DIFF
--- a/docs/releases/0.9.5.md
+++ b/docs/releases/0.9.5.md
@@ -1,0 +1,58 @@
+# Assegai Console 0.9.5 Release Notes
+
+Released: 2026-06-21
+
+## Overview
+
+Assegai Console 0.9.5 focuses on migration reliability and project-root path resolution. It improves how migration SQL files are executed across database drivers, gives SQLite migrations safer transaction behavior, and makes `assegai serve --root` more predictable for parent-relative and resolved project paths.
+
+## Highlights
+
+### More reliable migration script execution
+
+- Migration runners now use a shared SQL script execution path instead of each migrator handling script execution differently.
+- Multi-statement migration files are handled more consistently across supported database drivers.
+- Drivers that can leave pending result sets now drain script rowsets before the next query runs, avoiding errors such as pending-result-set failures after a multi-statement migration.
+- Pending migration lists are re-indexed after filtering already-ran migrations, so limited migration runs process the expected migrations in order.
+
+### Safer SQLite migrations
+
+- SQLite migration scripts now run inside a framework-managed transaction when the script is safe to wrap.
+- The migration script and migration-table record update are committed together for transaction-safe scripts.
+- If a later statement in a transaction-safe SQLite script fails, earlier statements are rolled back and the migration remains pending.
+- SQLite scripts containing autocommit-only statements such as `VACUUM` and selected `PRAGMA` statements run outside an explicit framework transaction.
+- SQLite scripts that manage their own transaction with `BEGIN`, `COMMIT`, or `ROLLBACK` are no longer wrapped in an outer transaction.
+- Comments, strings, quoted identifiers, and trigger bodies are handled by the script scanner so transaction decisions are based on real top-level statements rather than incidental text.
+
+### Better serve-root resolution
+
+- `assegai serve --root ../other-project` now resolves the root relative to the current working directory before normalization.
+- Symlinked root paths are resolved through the filesystem before parent segments are collapsed, so `--root link/../app` points at the intended project.
+- The shared path utility now handles Unix absolute paths, drive-letter absolute paths, and UNC-style roots more consistently when those path forms are encountered.
+- UNC share roots are preserved while normalizing parent segments, avoiding accidental resolution to a different network location.
+
+### SQLite database path normalization
+
+- SQLite database path handling now uses the shared path utility for absolute-path detection and normalization.
+- Relative SQLite database paths still resolve inside the project root as before.
+
+## Upgrade Notes
+
+- No application code changes are required.
+- Existing migration files can continue to contain multiple SQL statements.
+- SQLite migrations that already include their own `BEGIN ... COMMIT` block do not need to be rewritten.
+- SQLite migrations that use `VACUUM` or autocommit-only `PRAGMA` statements are supported, but those scripts cannot be rolled back atomically by SQLite.
+- Projects using `serve --root` with parent-relative or symlinked paths should now see the CLI resolve the intended project root more consistently.
+
+## Validation
+
+This release adds regression coverage for:
+
+- multi-statement migration script execution
+- drained rowsets after migration scripts
+- SQLite transaction rollback for failed multi-statement migrations
+- SQLite autocommit-only migration scripts
+- SQLite migration scripts with explicit transaction blocks
+- pending migration list key normalization
+- parent-relative, symlinked, absolute, and UNC-style path normalization
+- `serve --root` project-root resolution


### PR DESCRIPTION
This pull request adds release notes for Assegai Console 0.9.5, highlighting improvements to migration reliability and project-root path resolution. The release focuses on making migration script execution more consistent across database drivers, improving SQLite migration safety, and enhancing how the CLI resolves project roots, especially with parent-relative and symlinked paths.

Migration reliability improvements:

* Migration runners now use a shared SQL script execution path, ensuring consistent handling of multi-statement migration files and draining pending rowsets across all supported database drivers.
* Pending migration lists are re-indexed after filtering already-ran migrations, so limited migration runs process the expected migrations in order.

SQLite migration safety:

* SQLite migration scripts are now wrapped in framework-managed transactions when safe, ensuring that failed statements roll back changes and leave the migration pending. Scripts with autocommit-only statements or explicit transaction blocks are handled appropriately.
* The migration script scanner now accurately detects transaction boundaries by parsing comments, strings, quoted identifiers, and trigger bodies.

Project-root and path resolution:

* The CLI’s `assegai serve --root` now resolves project roots more predictably, handling parent-relative, symlinked, Unix, drive-letter, and UNC-style paths consistently. SQLite database path normalization also uses the improved shared path utility.